### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/saap/pom.xml
+++ b/saap/pom.xml
@@ -17,7 +17,7 @@
   	<org.slf4j.version>1.7.6</org.slf4j.version>
 	<log4j.version>1.2.16</log4j.version>
 	<commons-beanutils.version>1.8.3</commons-beanutils.version>
-	<commons-collections.version>3.2.1</commons-collections.version>
+	<commons-collections.version>3.2.2</commons-collections.version>
 	<commons-configuration.version>1.8</commons-configuration.version>
 	<commons-fileupload.version>1.3</commons-fileupload.version>
 	<commons-lang.version>2.5</commons-lang.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
